### PR TITLE
Fix mobile base usage + add ability to change end effector in geometric_simu

### DIFF
--- a/roscontrol_sot_tiago/launch/controller.launch
+++ b/roscontrol_sot_tiago/launch/controller.launch
@@ -2,7 +2,7 @@
   <arg name="use_mobile_base" doc="Whether SoT should control the mobile base"/>
   <arg name="simulation" default="false"/>
 
-  <param if="$(arg simulation)" name="/sot_controller/use_mobile_base" value="$(arg use_mobile_base)"/>
+  <param name="/sot_controller/use_mobile_base" value="$(arg use_mobile_base)"/>
 
   <!-- Sot Controller configuration -->
   <rosparam command="load" file="$(find roscontrol_sot_tiago)/config/sot_params.yaml"/>

--- a/sot_tiago_bringup/launch/geometric_simu.launch
+++ b/sot_tiago_bringup/launch/geometric_simu.launch
@@ -6,10 +6,12 @@
   <arg name="use_mobile_base" doc="Whether SoT should control the mobile base"/>
   <arg name="robot" default="tiago" />
   <arg name="libsot" default="libsot-tiago-steel-controller.so" />
+  <arg name="end_effector" doc="one of false, pal-gripper, pal-hey5, schunk-wsg"/>
 
   <arg name="sot-launch-prefix" default="" />
 
-  <include file="$(find sot_tiago_bringup)/launch/geometric_simu_context.launch" >
+  <include file="$(find sot_tiago_bringup)/launch/geometric_simu_context.launch">
+    <arg name="end_effector" value="$(arg end_effector)"/>
   </include>
 
   <param name="/sot_controller/use_mobile_base" value="$(arg use_mobile_base)"/>

--- a/sot_tiago_bringup/launch/geometric_simu_context.launch
+++ b/sot_tiago_bringup/launch/geometric_simu_context.launch
@@ -2,11 +2,16 @@
      Handle ROS simulation of the SoT.
   -->
 <launch>
-  <!-- BTW we are in simulation ? -->
+  <arg name="end_effector" doc="one of false, pal-gripper, pal-hey5, schunk-wsg"/>
 
    <!-- Load robot model. -->
+  <!--
   <param name="robot_description"
-	 textfile="$(find tiago_data)/robots/tiago_steel.urdf" />
+    textfile="$(find tiago_data)/robots/tiago_steel.urdf" />
+  -->
+  <param name="robot_description"
+    command="$(find xacro)/xacro.py '$(find tiago_description)/robots/tiago.urdf.xacro' end_effector:=$(arg end_effector)"/>
+
 
 
    <!-- Load robot sot params. -->


### PR DESCRIPTION
Note that this removes the ability to use the mobile base in geometric_simu because SoT does not handle continuous joints.